### PR TITLE
Add GitHub Release workflow config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Build
+      run: python ./build.py
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ./build/releases/*.aseprite-extension

--- a/build.py
+++ b/build.py
@@ -19,9 +19,11 @@ def main():
 
     package_json_file_path = os.path.join(data_dir, 'package.json')
     with open(package_json_file_path, 'r', encoding='utf-8') as file:
-        version: str = json.loads(file.read())['version']
+        package_info: dict = json.loads(file.read())
 
-    extension_file_path = os.path.join(releases_dir, f'language-italian-v{version}.aseprite-extension')
+    package_name: str = package_info['name']
+    package_version: str = package_info['version']
+    extension_file_path = os.path.join(releases_dir, f'{package_name}-v{package_version}.aseprite-extension')
     with zipfile.ZipFile(extension_file_path, 'w') as file:
         for file_dir, _, file_names in os.walk(data_dir):
             for file_name in file_names:

--- a/data/package.json
+++ b/data/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aseprite-language-italian",
+  "name": "language-italian",
   "displayName": "italiano",
   "description": "Traduzione in italiano da parte di Fabiano Caputo. Per suggerimenti o commenti, per favore scrivetemi a fabiano.caputo@outlook.it o contattatemi sul forum di Aseprite.",
   "version": "1.3-rc5",


### PR DESCRIPTION
This workflow helps to automatically build package and upload `*.aseprite-extension` to the release page. Just create a `tag` and create a `release` from this `tag`.

Notice that, the file name is: {package_name}-v{package_version}.aseprite-extension
https://github.com/aseprite-quest/aseprite-language-italian/blob/workflows_release/build.py#L26

package use  https://github.com/FabianoIlCapo/aseprite_italian/blob/master/data/package.json